### PR TITLE
Fully support template files including template files

### DIFF
--- a/build-docs.rb
+++ b/build-docs.rb
@@ -45,7 +45,7 @@ def cleanup_and_clone(clone_target, git, ref, inject_central_docs = false)
     puts "Checking out #{ref}"
     %x(git --git-dir=#{clone_target}/.git --work-tree=#{clone_target} checkout #{ref} #{@git_options})
 
-    if inject_central_docs 
+    if inject_central_docs
       puts "Inject Central Docs"
       %x(git config --global user.email "info@icinga.com")
       %x(git config --global user.name "Icinga Docs Tool")
@@ -97,7 +97,7 @@ def build_page_index(full_docs_dir, project_docs_dir, package = "", product = ""
       subdirectory = []
       nav_item = titleize(filename[2]) unless File.symlink?(filepath)
       is_template_dir = !filename[3].nil?
-  
+
       Dir.glob("#{file}/*.md", File::FNM_CASEFOLD).sort.each do |subfile|
         subfile_path = subfile.gsub(full_docs_dir + '/', project_docs_dir + '/')
         # Get everything after last slash
@@ -122,7 +122,7 @@ def build_page_index(full_docs_dir, project_docs_dir, package = "", product = ""
 
           subfile_path = subfile_path.gsub(subdir_name, new_subdir_name)
         end
-  
+
         header = titleize(subfile_name[1]) unless File.symlink?(subfile)
         subdirectory.push(header => subfile_path) if header
       end
@@ -158,9 +158,9 @@ def build_page_index(full_docs_dir, project_docs_dir, package = "", product = ""
           subdirectory.unshift(filepath.gsub(/.md.d$/, '') + '/index.md')
         end
       end
-  
+
       pages.push(nav_item => subdirectory) if nav_item
-    else  
+    else
       header = titleize(filename[2]) unless File.symlink?(filepath)
       pages.push(header => filepath) if header
     end


### PR DESCRIPTION
This update enables markdown files in the template directory to include other
files from the same directory, providing full support for Jinja templates.
Previously, when a file included another file that was naturally ordered before
it, the templates were already resolved due to in-place modifications. Now,
rather than modifying template files directly and renaming them later, they are
written to the target location instead.