### PR TITLE
Sort "For Container" install section to bottom

### DIFF
--- a/build-docs.rb
+++ b/build-docs.rb
@@ -127,12 +127,15 @@ def build_page_index(full_docs_dir, project_docs_dir, package = "", product = ""
         subdirectory.push(header => subfile_path) if header
       end
 
-      # Sort the "From Source" installation guide explicitly to the end
-      subdirectory.each_with_index do |subdirectory_element, index|
-        if subdirectory_element.key?("From Source")
-          subdirectory.append(subdirectory_element)
-          subdirectory.delete_at(index)
-          break
+      # Sort the "For Container" and "From Source" installation sections
+      # explicitly to the end. "For Container" precedes "From Source".
+      ["For Container", "From Source"].each do |section_name|
+        subdirectory.each_with_index do |subdirectory_element, index|
+          if subdirectory_element.key?(section_name)
+            subdirectory.append(subdirectory_element)
+            subdirectory.delete_at(index)
+            break
+          end
         end
       end
 


### PR DESCRIPTION
For Icinga DB 1.4.0, a new "For Container" installation subsection was introduced. Since each section except "From Source" is sorted alphabetically, the "For Container" section appeared a bit lost in between. A similar code as "From Source" was introduced, ensuring that the new section is shown second to last.